### PR TITLE
Add earl-hyperscript to Utilities section

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ http://oleg.fi/graafi
  
 * [andreloureiro/cyclejs-starter](https://github.com/andreloureiro/cyclejs-starter) - Cycle.js starter template with ES6 and Livereload.
 
+* [madcapjake/earlhyperscript](https://github.com/MadcapJake/earl-hyperscript) - A helper function and macro for using Earl Grey's [document-building syntax](https://breuleux.github.io/earl-grey/doc.html#documentbuildingsyntax) with Cycle.js.
+
 ### Testing
 
 * [erykpiast/cyclejs-mock](https://github.com/erykpiast/cyclejs-mock) - Utility for testing applications based on CycleJS framework.


### PR DESCRIPTION
[earl-hyperscript](https://github.com/MadcapJake/earl-hyperscript) provides a helper function and a macro to convert Earl Grey's document-building syntax to the same virtual DOM elements that Cycle.js expects. [Earl Grey](https://breuleux.github.io/earl-grey/) is a fun compile-to-JS language that works really well with Cycle.js (to use Cycle.js with Earl Grey, there is a [transform](https://github.com/breuleux/earlify) for browserify, a [loader](https://github.com/madcapjake/earlgrey-loader) for webpack, and work has started on a [plugin](https://github.com/MadcapJake/plugin-earlgrey) for SystemJS)
