### PR TITLE
Add cycle-time-travel under new Debugging section

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ http://oleg.fi/graafi
 
 * [erykpiast/cyclejs-mock](https://github.com/erykpiast/cyclejs-mock) - Utility for testing applications based on CycleJS framework.
 
+### Debugging
+
+* [cyclejs/cycle-time-travel](https://github.com/cyclejs/cycle-time-travel) - A time travelling debugger for Cycle.js. Try it online [here](http://cycle.js.org/cycle-time-travel).
+
 ### Components
 
 * [erykpiast/autocompleted-select](https://github.com/erykpiast/autocompleted-select) - Select Web Component with autocompletion. Based on RxJS and VirtualDOM.

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ http://oleg.fi/graafi
 
 ### Debugging
 
-* [cyclejs/cycle-time-travel](https://github.com/cyclejs/cycle-time-travel) - A time travelling debugger for Cycle.js. Try it online [here](http://cycle.js.org/cycle-time-travel).
+* [cyclejs/cycle-time-travel](https://github.com/cyclejs/cycle-time-travel) - A time travelling debugger for Cycle.js apps. Displays a stream visualizer that you can drag to go back in time. Try it online [here](http://cycle.js.org/cycle-time-travel).
 
 ### Components
 


### PR DESCRIPTION
`cycle-time-travel` didn't really seem to fit with any of the other libraries in the other categories, so I added a new one. Happy to put it somewhere else if you like.
