### PR TITLE
Fix broken link on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A collection of awesome Cycle.js tools, resources, videos and shiny things.
 
 ### Slides
 
-* [Cycle.js an honestly reactive framework for web user interfaces](http://slides.com/eryknapierala/cycle) - by Eryk Napierała
+* [Cycle.js an honestly reactive framework for web user interfaces](http://slides.com/erykpiast/cycle) - by Eryk Napierała
 
 ### Example Applications
 


### PR DESCRIPTION
I found that http://slides.com/eryknapierala/cycle was renamed with http://slides.com/erykpiast/cycle.
## http://slides.com/eryknapierala/cycle

![image](https://cloud.githubusercontent.com/assets/111689/10262409/ce81527a-6a00-11e5-88f0-f28ffe1915e0.png)
## http://slides.com/erykpiast/cycle

![image](https://cloud.githubusercontent.com/assets/111689/10262412/e1a9aeba-6a00-11e5-924c-bb69a44de015.png)
