### PR TITLE
Bring in tricycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ A collection of awesome Cycle.js tools, resources, videos and shiny things.
 
 * [cyclejs/cycle-examples](https://github.com/cyclejs/cycle-examples) - Official collection of small Cycle.js examples
 
+* [Widdershin/tricycle](https://github.com/Widdershin/tricycle) - Scratchpad for trying out Cycle.js, relies on Ace Editor with Cycle
+
 * [cgeorg/todomvp](https://github.com/cgeorg/todomvp) - Minimum Viable Pizza, an example webapp written in Cycle.js
 
 * [erykpiast/cyclejs-examples](https://github.com/erykpiast/cyclejs-examples) - Example web applications built with Cycle.js.


### PR DESCRIPTION
In looking for examples that relied on a TextArea, CodeMirror, or Ace Editor I noticed that [Try Cycle](http://widdersh.in/tricycle/) relies on the Ace Editor so I'm highlighting it here.

I'd like to see if tricycle can be done without a global editor as I'd like to make pages that have multiple editors on the page (and don't want to maintain multiple editors on the screen). If there's another pattern here or example to highlight, I'd love to read it!
