### PR TITLE
Added stars and fixed broken links via awesome-lists-bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,28 +50,27 @@ A collection of awesome Cycle.js tools, resources, videos and shiny things.
 
 ### Example Applications
 
-* [**cyclejs/cycle-examples ★141**](https://github.com/cyclejs/examples) - Official collection of small Cycle.js examples
-* [Widdershin/tricycle ★19](https://github.com/Widdershin/tricycle) - Scratchpad for trying out Cycle.js, relies on Ace Editor with Cycle
-* [cgeorg/todomvp ★17](https://github.com/cgeorg/todomvp) - Minimum Viable Pizza, an example webapp written in Cycle.js
-* [erykpiast/cyclejs-examples ★7](https://github.com/erykpiast/cyclejs-examples) - Example web applications built with Cycle.js.
+* [**cyclejs/cycle-examples ★180**](https://github.com/cyclejs/examples) - Official collection of small Cycle.js examples
+* [Widdershin/tricycle ★20](https://github.com/Widdershin/tricycle) - Scratchpad for trying out Cycle.js, relies on Ace Editor with Cycle
+* [cgeorg/todomvp ★18](https://github.com/cgeorg/todomvp) - Minimum Viable Pizza, an example webapp written in Cycle.js
+* [erykpiast/cyclejs-examples ★8](https://github.com/erykpiast/cyclejs-examples) - Example web applications built with Cycle.js.
 * [grozen/trends-cycle ★3](https://github.com/grozen/trends-cycle) - Slack trend searching written in Cycle.js
-* [ivan-kleshnin/cyclejs-examples ★86](https://github.com/ivan-kleshnin/cyclejs-examples) - Collection of CycleJS examples, ES6.
-* [ivan-kleshnin/tetris-cyclejs ★7](https://github.com/ivan-kleshnin/tetris-game) - Tetris game implemented in CycleJS, ES6
-* [phadej/graafi ★13](https://github.com/phadej/graafi) - Cycle.js experiment with SVG and global undo/redo
+* [ivan-kleshnin/cyclejs-examples ★98](https://github.com/ivan-kleshnin/cyclejs-examples) - Collection of CycleJS examples, ES6.
+* [ivan-kleshnin/tetris-cyclejs ★10](https://github.com/ivan-kleshnin/tetris-game) - Tetris game implemented in CycleJS, ES6
+* [phadej/graafi ★17](https://github.com/phadej/graafi) - Cycle.js experiment with SVG and global undo/redo
 http://oleg.fi/graafi/
-* [**staltz/rxmarbles ★1,022**](https://github.com/staltz/rxmarbles) - Interactive diagrams of Rx Observables http://rxmarbles.com/
+* [**staltz/rxmarbles ★1,323**](https://github.com/staltz/rxmarbles) - Interactive diagrams of Rx Observables http://rxmarbles.com/
 * [MarcCloud/magic-cart ★6](https://github.com/MarcCloud/magic-cart) - Simple shopping cart of a magic creatures store.
-* [foxdonut/cycle-todolist ★9](https://github.com/foxdonut/cycle-todolist) - demonstrates a simple Cycle.js TODO list app with CRUD.
-* [collardeau/kairos ★13](https://github.com/collardeau/kairos) - Source code for [Kairos](http://my-kairos.herokuapp.com/), a weather app built in Cycle.js.
-* [**Mercateo/component-check ★417**](https://github.com/Mercateo/component-check) - Common patterns for building Cycle.js components
-* [edge/electron-cycle-media ★23](https://github.com/edge/electron-cycle-media) - Media player written with Cycle.js and Electron.
+* [foxdonut/cycle-todolist ★10](https://github.com/foxdonut/cycle-todolist) - demonstrates a simple Cycle.js TODO list app with CRUD.
+* [**Mercateo/component-check ★437**](https://github.com/Mercateo/component-check) - Common patterns for building Cycle.js components
+* [edge/electron-cycle-media ★26](https://github.com/edge/electron-cycle-media) - Media player written with Cycle.js and Electron.
 * [kibin/cycle-example-who-to-follow ★16](https://github.com/kibin/cycle-example-who-to-follow) - Small example partly implements twitter’s who to follow box using github api.
-* [SkaterDad/cycle-snabbdom-examples ★4](https://github.com/SkaterDad/cycle-snabbdom-examples) - Examples of nested components, using snabbdom-specific animations.
-* [bahmutov/draw-cycle ★81](https://github.com/bahmutov/draw-cycle) - Interactive visualization of counter application showing the data flow inside a MVI component [glebbahmutov.com/draw-cycle](https://glebbahmutov.com/draw-cycle/)
-* [andreloureiro/pomocycle ★3](https://github.com/andreloureiro/pomocycle) - A simple Pomodoro timer.
-* [laszlokorte/tams-tools ★6](https://github.com/laszlokorte/tams-tools) - A set of tools for teaching and learning computer science built with cycle.js.
-* [lucamezzalira/jsday-cycle-js ★6](https://github.com/lucamezzalira/jsday-cycle-js) - Reactive Live London Tube trains status example built with Cycle.js.
-* [cyclejs-community/built-with-cycle](https://github.com/cyclejs-community/built-with-cycle) - [A website](http://cyclejs-community.github.io/built-with-cycle) to showcase the cool projects built with Cycle.js
+* [SkaterDad/cycle-snabbdom-examples ★6](https://github.com/SkaterDad/cycle-snabbdom-examples) - Examples of nested components, using snabbdom-specific animations.
+* [bahmutov/draw-cycle ★93](https://github.com/bahmutov/draw-cycle) - Interactive visualization of counter application showing the data flow inside a MVI component [glebbahmutov.com/draw-cycle](https://glebbahmutov.com/draw-cycle/)
+* [andreloureiro/pomocycle ★10](https://github.com/andreloureiro/pomocycle) - A simple Pomodoro timer.
+* [laszlokorte/tams-tools ★18](https://github.com/laszlokorte/tams-tools) - A set of tools for teaching and learning computer science built with cycle.js.
+* [lucamezzalira/jsday-cycle-js ★8](https://github.com/lucamezzalira/jsday-cycle-js) - Reactive Live London Tube trains status example built with Cycle.js.
+* [cyclejs-community/built-with-cycle ★4](https://github.com/cyclejs-community/built-with-cycle) - [A website](http://cyclejs-community.github.io/built-with-cycle) to showcase the cool projects built with Cycle.js
 * [class-ideas/cyclejs-hangman ★7](https://github.com/class-ideas/cyclejs-hangman) A hangman game built with Cycle.js
 
 
@@ -79,30 +78,30 @@ http://oleg.fi/graafi/
 
 ### Drivers
 
-* [cyclejs/cycle-http-driver ★51](https://github.com/cyclejs/http) - A Cycle.js Driver for making HTTP requests, based on superagent.
-* [cyclejs/cycle-storage-driver ★20](https://github.com/cyclejs/cycle-storage-driver) - A Cycle.js Driver for using localStorage and sessionStorage.
-* [cyclejs/cycle-notification-driver ★15](https://github.com/cyclejs/cycle-notification-driver) - A Cycle.js Driver for showing and responding to HTML5 Notifications.
+* [cyclejs/cycle-http-driver ★58](https://github.com/cyclejs/http) - A Cycle.js Driver for making HTTP requests, based on superagent.
+* [cyclejs/cycle-storage-driver ★21](https://github.com/cyclejs/storage) - A Cycle.js Driver for using localStorage and sessionStorage.
+* [cyclejs/cycle-notification-driver ★18](https://github.com/cyclejs/cycle-notification-driver) - A Cycle.js Driver for showing and responding to HTML5 Notifications.
 * [axefrog/cycle-router5 ★28](https://github.com/axefrog/cycle-router5) - A router driver using Router5
-* [cgeorg/cycle-socket.io ★15](https://github.com/cgeorg/cycle-socket.io) - A Cycle driver for Socket.IO clients
-* [**cyclejs/cycle-dom ★141**](https://github.com/cyclejs/dom) - The standard DOM Driver for Cycle.js based on virtual-dom, and other helpers
-* [secobarbital/cycle-fetch-driver ★1](https://github.com/secobarbital/cycle-fetch-driver) - A Cycle.js Driver for making HTTP requests, using the Fetch API.
-* [r7kamura/cycle-fetcher-driver ★12](https://github.com/r7kamura/cycle-fetcher-driver) - A Cycle.js Driver for making HTTP requests using [stackable-fetcher](https://github.com/r7kamura/stackable-fetcher).
-* [cyclejs/cycle-history ★58](https://github.com/cyclejs/history) - The standard Cycle driver for dealing with the [History API](https://developer.mozilla.org/en-US/docs/Web/API/History_API)
-* [benji6/cycle-audio-graph ★9](https://github.com/benji6/cycle-audio-graph) - A Cycle.js Driver for manipulating the Web Audio API using [virtual-audio-graph](https://github.com/benji6/virtual-audio-graph)
+* [cgeorg/cycle-socket.io ★16](https://github.com/cgeorg/cycle-socket.io) - A Cycle driver for Socket.IO clients
+* [**cyclejs/cycle-dom ★162**](https://github.com/cyclejs/dom) - The standard DOM Driver for Cycle.js based on virtual-dom, and other helpers
+* [secobarbital/cycle-fetch-driver ★2](https://github.com/secobarbital/cycle-fetch-driver) - A Cycle.js Driver for making HTTP requests, using the Fetch API.
+* [r7kamura/cycle-fetcher-driver ★13](https://github.com/r7kamura/cycle-fetcher-driver) - A Cycle.js Driver for making HTTP requests using [stackable-fetcher](https://github.com/r7kamura/stackable-fetcher).
+* [cyclejs/cycle-history ★62](https://github.com/cyclejs/history) - The standard Cycle driver for dealing with the [History API](https://developer.mozilla.org/en-US/docs/Web/API/History_API)
+* [benji6/cycle-audio-graph ★11](https://github.com/benji6/cycle-audio-graph) - A Cycle.js Driver for manipulating the Web Audio API using [virtual-audio-graph](https://github.com/benji6/virtual-audio-graph)
 * [CyclicMaterials/cycle-hammer-driver ★10](https://github.com/CyclicMaterials/cycle-hammer-driver) - A Cycle.js driver to wrap Hammer.js and detect touch gestures
-* [jessaustin/cycle-sse-driver ★4](https://github.com/jessaustin/cycle-sse-driver) - Source driver for Server-Sent Events/EventSource.
-* [tylors/cycle-snabbdom ★41](https://github.com/TylorS/cycle-snabbdom) - DOM driver using Snabbdom
+* [jessaustin/cycle-sse-driver ★5](https://github.com/jessaustin/cycle-sse-driver) - Source driver for Server-Sent Events/EventSource.
+* [tylors/cycle-snabbdom ★42](https://github.com/TylorS/cycle-snabbdom) - DOM driver using Snabbdom
 * [cyclejs-community/cyclic-router ★43](https://github.com/cyclejs-community/cyclic-router) - Router Driver built for Cycle.js
-* [Widdershin/cycle-animation-driver ★22](https://github.com/Widdershin/cycle-animation-driver) - Cycle driver for requestAnimationFrame
-* [dralletje/cycle-firebase ★15](https://github.com/dralletje/cycle-firebase) - A Cycle.js Driver for Firebase
-* [edge/cycle-blessed ★26](https://github.com/edge/cycle-blessed) - A Cycle.js Driver for terminal applications
-* [10clouds/cyclejs-cookie ★0](https://github.com/10clouds/cyclejs-cookie) - Cookies Driver for Cycle.js
-* [whitecolor/cycle-async-driver ★7](https://github.com/whitecolor/cycle-async-driver) - Factory for creating async request/response cycle.js drivers
-* [raquelxmoss/cycle-keys ★9](https://github.com/raquelxmoss/cycle-keys) - Driver for keyboard events
+* [Widdershin/cycle-animation-driver ★25](https://github.com/Widdershin/cycle-animation-driver) - Cycle driver for requestAnimationFrame
+* [dralletje/cycle-firebase ★17](https://github.com/dralletje/cycle-firebase) - A Cycle.js Driver for Firebase
+* [edge/cycle-blessed ★35](https://github.com/edge/cycle-blessed) - A Cycle.js Driver for terminal applications
+* [10clouds/cyclejs-cookie ★1](https://github.com/10clouds/cyclejs-cookie) - Cookies Driver for Cycle.js
+* [whitecolor/cycle-async-driver ★15](https://github.com/whitecolor/cycle-async-driver) - Factory for creating async request/response cycle.js drivers
+* [raquelxmoss/cycle-keys ★26](https://github.com/raquelxmoss/cycle-keys) - Driver for keyboard events
 * [rektide/recyclec ★0](https://github.com/rektide/recyclec) - Readline driver
-* [goodmind/cycle-telegram ★2](https://github.com/goodmind/cycle-telegram) - A Cycle.js Driver for Telegram Bot API
-* [apoco/cycle-electron-driver](https://github.com/apoco/cycle-electron-driver) - Driver to interact with Electron interface from Cycle.js application
-* [rkrupinski/cyclejs-animated-localstorage](https://github.com/rkrupinski/cyclejs-animated-localstorage) - A Cycle.js driver for animating (srsly) localStorage.
+* [goodmind/cycle-telegram ★13](https://github.com/goodmind/cycle-telegram) - A Cycle.js Driver for Telegram Bot API
+* [apoco/cycle-electron-driver ★14](https://github.com/apoco/cycle-electron-driver) - Driver to interact with Electron interface from Cycle.js application
+* [rkrupinski/cyclejs-animated-localstorage ★4](https://github.com/rkrupinski/cyclejs-animated-localstorage) - A Cycle.js driver for animating (srsly) localStorage.
 * [cyclejs-community/cycle-keyboard ★1](https://github.com/cyclejs-community/cycle-keyboard) - A keyboard driver for cycle.js
 
 ### Utilities
@@ -110,36 +109,35 @@ http://oleg.fi/graafi/
 * [staltz/chai-virtual-dom ★22](https://github.com/staltz/chai-virtual-dom) - Chai assertion helpers to test virtual-dom VTrees
 * [cgeorg/sinject ★10](https://github.com/cgeorg/sinject) - a dependency injection tool supporting Cycle's circular dependencies
 * [erykpiast/cyclejs-group ★19](https://github.com/erykpiast/cyclejs-group) - Utility for CycleJS framework for reducing boilerplate when creating groups of streams.
-* [erykpiast/cyclejs-stream ★25](https://github.com/cyclejs/rx-injectable-observable) - Observable (events stream) to which you can inject another streams.
-* [erykpiast/cyclejs-wc ★0](https://github.com/erykpiast/cyclejs-wc) - Utility for creating Web Components based on Cycle.js
-* [**ohanhi/hyperscript-helpers ★237**](https://github.com/ohanhi/hyperscript-helpers) - elm-html inspired helpers for writing hyperscript or virtual-hyperscript.
-* [**pH200/cycle-react ★234**](https://github.com/pH200/cycle-react) - use React instead of virtual-dom with a Cycle-like API
+* [erykpiast/cyclejs-wc ★1](https://github.com/erykpiast/cyclejs-wc) - Utility for creating Web Components based on Cycle.js
+* [**ohanhi/hyperscript-helpers ★270**](https://github.com/ohanhi/hyperscript-helpers) - elm-html inspired helpers for writing hyperscript or virtual-hyperscript.
+* [**pH200/cycle-react ★264**](https://github.com/pH200/cycle-react) - use React instead of virtual-dom with a Cycle-like API
 * [madcapjake/earlhyperscript ★2](https://github.com/MadcapJake/earl-hyperscript) - A helper function and macro for using Earl Grey's [document-building syntax](https://breuleux.github.io/earl-grey/doc.html#documentbuildingsyntax) with Cycle.js.
-* [WorldMaker/cycle-gear](https://github.com/WorldMaker/cycle-gear) - A main function factory for Cycle based upon a formalization of Cycle's MVI pattern
+* [WorldMaker/cycle-gear ★1](https://github.com/WorldMaker/cycle-gear) - A main function factory for Cycle based upon a formalization of Cycle's MVI pattern
 
 ### Boilerplates
 
-* [andreloureiro/cyclejs-starter ★27](https://github.com/andreloureiro/cyclejs-starter) - Cycle.js starter template with ES6 and Livereload.
+* [andreloureiro/cyclejs-starter ★37](https://github.com/andreloureiro/cyclejs-starter) - Cycle.js starter template with ES6 and Livereload.
 * [Frikki/generator-cyclejs ★1](https://github.com/Frikki/generator-cyclejs) - Scaffold out a Cycle.js Nested Dialogue module using Yeoman.
-* [adicirstei/cycle-bp ★4](https://github.com/adicirstei/cycle-bp) - Boilerplate template for building Cycle.js apps
-* [edge/cyc ★82](https://github.com/edge/cyc) - Scaffold an isomorphic Cycle.js app in seconds.
-* [cmdv/cycle-webpack-boilerplate ★63](https://github.com/Cmdv/cycle-webpack-boilerplate) - Cycle app with routing, state handling and tests.
+* [adicirstei/cycle-bp ★5](https://github.com/adicirstei/cycle-bp) - Boilerplate template for building Cycle.js apps
+* [**edge/cyc ★130**](https://github.com/edge/cyc) - Scaffold an isomorphic Cycle.js app in seconds.
+* [cmdv/cycle-webpack-boilerplate ★78](https://github.com/Cmdv/cycle-webpack-boilerplate) - Cycle app with routing, state handling and tests.
 * [Widdershin/cycle-hot-reloading-example ★25](https://github.com/Widdershin/cycle-hot-reloading-example) - A Cycle.js starter project with hot reloading using browserify-hmr
 * [mciparelli/cycle-hmr-example ★0](https://github.com/mciparelli/cycle-hmr-example) - A Cycle.js starter project using browserify and cycle-hmr
 * [cycle-community/typescript-starter-cycle ★2](https://github.com/cyclejs-community/typescript-starter-cycle) - A simple project for getting started with TypeScript in cycle.js, using Webpack. Has settings for Visual Studio Code as candy.
 
 ### Testing
 
-* [erykpiast/cyclejs-mock ★16](https://github.com/erykpiast/cyclejs-mock) - Utility for testing applications based on CycleJS framework.
+* [erykpiast/cyclejs-mock ★20](https://github.com/erykpiast/cyclejs-mock) - Utility for testing applications based on CycleJS framework.
 
 ### Debugging
 
-* [**cyclejs/cycle-time-travel ★138**](https://github.com/cyclejs/cycle-time-travel) - A time travelling debugger for Cycle.js apps. Displays a stream visualizer that you can drag to go back in time. Try it online [here](http://cycle.js.org/cycle-time-travel/).
+* [**cyclejs/cycle-time-travel ★158**](https://github.com/cyclejs/cycle-time-travel) - A time travelling debugger for Cycle.js apps. Displays a stream visualizer that you can drag to go back in time. Try it online [here](http://cycle.js.org/cycle-time-travel/).
 
 ### Components
 
 * [erykpiast/autocompleted-select ★9](https://github.com/erykpiast/autocompleted-select) - Select Web Component with autocompletion. Based on RxJS and VirtualDOM.
-* [enten/cyclejs-calendar ★6](https://github.com/enten/cyclejs-calendar) - Calendar component for Cycle.js. Try it online [here](http://enten.github.io/cyclejs-calendar/example).
+* [enten/cyclejs-calendar ★9](https://github.com/enten/cyclejs-calendar) - Calendar component for Cycle.js. Try it online [here](http://enten.github.io/cyclejs-calendar/example).
 * [mciparelli/cyclejs-gravatar ★0](https://github.com/mciparelli/cyclejs-gravatar) - Cycle.js component for rendering a gravatar profile image.
 * [tommy-the-runner/cyclejs-ace-editor ★0](https://github.com/tommy-the-runner/cyclejs-ace-editor) - Cycle.js intergration with Ace Editor using [brace](https://github.com/thlorenz/brace). Check an example [here](https://tommy-the-runner.github.io/cyclejs-ace-editor/).
 


### PR DESCRIPTION
This Pull Request has been generated automatically by awesome-lists-bot, which was created by @ColinEberhardt. The aim of this bot is to improve the overall standard of the various GitHub-based 'awesome' lists.

For questions / comments regarding the bot, or to have your awesome repo removed from the list, please add an issue here:

https://github.com/ColinEberhardt/awesome-lists-bot

Currently the bot does the following:
- Removes links that returns 404s (please double check these deletions before merging in case it is a temporary issue)
- Add a star count for repos, this helps people find popular projects (especially useful for big lists!)
- Resolve redirects, updating the project / org name when a redirect is found.

Although I am beta-testing some of these features on a subset of awesome lists.

Here's a summary of changes as part of this PR:

Awesome link checker verified 87 links, finding 2 broken
- [404] http://my-kairos.herokuapp.com/ [REMOVED]
- [404] https://github.com/cyclejs/rx-injectable-observable [REMOVED]
