### PR TITLE
Added HapiCycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ http://oleg.fi/graafi/
 * [Widdershin/cycle-hot-reloading-example ★25](https://github.com/Widdershin/cycle-hot-reloading-example) - A Cycle.js starter project with hot reloading using browserify-hmr
 * [mciparelli/cycle-hmr-example ★0](https://github.com/mciparelli/cycle-hmr-example) - A Cycle.js starter project using browserify and cycle-hmr
 * [cycle-community/typescript-starter-cycle ★2](https://github.com/cyclejs-community/typescript-starter-cycle) - A simple project for getting started with TypeScript in cycle.js, using Webpack. Has settings for Visual Studio Code as candy.
+* [wyqydsyq/hapi-cycle ★0](https://github.com/wyqydsyq/hapi-cycle) - A boilerplate isomorphic Cycle app running on a Hapi server with a simple CRUD skeleton to get you started
 
 ### Testing
 


### PR DESCRIPTION
I've made a boilerplate similar to `edge/cyc` in functionality but using Hapi instead of express for the server, as well as a few other goodies thrown in.

I'm still working on it (it's usable and works out of the box, just needs some refactoring and optimization) so it's probably not safe for production yet, but should still save a lot of time for anyone looking to get an isomorphic Hapi + Cycle app up and running.

I'm not really sure if awesome-cyclejs is meant to be strictly production-ready stuff or if it includes have stuff that merely works.
If it's the former just say so and I'll resubmit this PR once HapiCycle is more mature.
